### PR TITLE
Implementation of calling R script 1

### DIFF
--- a/VariationalAutoencoder2DCNN/_NNVariationalAutoencoderEvaluator.gen.m
+++ b/VariationalAutoencoder2DCNN/_NNVariationalAutoencoderEvaluator.gen.m
@@ -66,7 +66,7 @@ YLatent = latentInfo{2};
 
 %figure;
 %h = scatter(ZLatent(1, index_selected), ZLatent(2, index_selected), 30, YLatent(index_selected), 'filled');
-h = scatter(ZLatent(1, :), ZLatent(2, :), 30, YLatent(:), 'filled');
+h = gscatter(ZLatent(1, :), ZLatent(2, :), YLatent, [], '.', 12);
 
 title('Scatter Plot with Color-Coded Categories');
 value = [];

--- a/VariationalAutoencoder2DCNN/pipeline_VAE2DCNN_MNIST.braph2
+++ b/VariationalAutoencoder2DCNN/pipeline_VAE2DCNN_MNIST.braph2
@@ -1,0 +1,20 @@
+%% Pipeline MNIST Variational Autoencoder with 2D CNN 
+
+% This is the pipeline script to execute cross-validation with multi-layer perceptron classifier using binary undirected graph at fix densities obtained from connectivity data.
+% The connectivity data can be derived from imaging modalities like diffusion weighted imaging (DWI).
+% 1. It loads a brain atlas from an XLS file (e.g., desikan_atlas.xlsx).
+% 2. It loads data for three groups of subjects from the directories (e.g., CON_Group_1_XLS, CON_Group_2_XLS, and CON_Group_3_XLS) containing XLS files for each subject.
+% 3. It analyzes these groups using connectivity analyses (CON) based on binary undirected graph at fix densities (BUD).
+% 4. It executes the cross-validation process.
+
+% PDF: 
+% README: 
+
+%% Dataset
+dproc = NNDatasetProcess_MNIST('MNIST_IMAGE_FILE', [fileparts(which('NNDatasetProcess_MNIST')) filesep 'mnist_data' filesep 'train-images-idx3-ubyte.gz'], 'MNIST_LABEL_FILE', [fileparts(which('NNDatasetProcess_MNIST')) filesep 'mnist_data' filesep 'train-labels-idx1-ubyte.gz']); % Load a Dataset % Image Dataset
+
+%% Model
+nnvae = NNVariationalAutoencoder2DCNN('D', dproc.get('D'), 'EPOCHS', 10, 'BATCH', 128); % Train a Variational Autoencoder % Variational Autoencoder
+
+%% Evaluation
+nne = NNVariationalAutoencoderEvaluator_Image('NN', nnvae, 'D', dproc.get('D')); % Evaluate the Variational Autoencoder % Variational Autoencoder Evaluation

--- a/VariationalAutoencoderRamanSpectra/R_files/Dockerfile
+++ b/VariationalAutoencoderRamanSpectra/R_files/Dockerfile
@@ -1,0 +1,35 @@
+# R 4.4.1 base (multi-arch; works on arm64/Apple Silicon)
+FROM rocker/r-ver:4.4.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# System libs for your package set (sf, magick, hdf5r, ragg, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential g++ gfortran make cmake patch pkg-config git \
+    libcurl4-openssl-dev libssl-dev libxml2-dev \
+    libhdf5-dev \
+    libmagick++-dev ghostscript \
+    libharfbuzz-dev libfribidi-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libpng-dev libjpeg-dev libtiff5-dev libwebp-dev \
+    libudunits2-dev libgdal-dev libgeos-dev libproj-dev libabsl-dev \
+    fonts-roboto fonts-ibm-plex \
+ && rm -rf /var/lib/apt/lists/*
+
+# Refresh font cache (helps hrbrthemes text rendering)
+RUN fc-cache -f -v
+
+# Pre-install CRAN pkgs + hrbrthemes from GitHub
+RUN R -q -e "options(repos=c(CRAN='https://cloud.r-project.org')); \
+  pkgs <- c( \
+    'tidyverse','ggpubr','R.matlab','hdf5r','cowplot','ggpattern','magick','here', \
+    'dplyr','scales','rstatix','car','sf','units','s2','ragg','ggrepel','viridis','ggsci','remotes' \
+  ); \
+  inst <- rownames(installed.packages()); \
+  to_install <- setdiff(pkgs, inst); \
+  if (length(to_install)) install.packages(to_install); \
+  remotes::install_github('hrbrmstr/hrbrthemes', upgrade='never')"
+
+WORKDIR /work
+CMD ["R","-q"]

--- a/VariationalAutoencoderRamanSpectra/_NNDatasetProcess_RamanSpectra.gen.m
+++ b/VariationalAutoencoderRamanSpectra/_NNDatasetProcess_RamanSpectra.gen.m
@@ -56,6 +56,22 @@ D (result, item) is the neural network dataset containing the datapoint processe
 raw_spectrum_list = dproc.get('EXTRACT_DATA');
 raw_label_list = dproc.get('EXTRACT_LABELS');
 
+targets_to_remove = dproc.get('TARGETS_TO_REMOVE');
+idx_to_remove = [];
+if ~isempty(targets_to_remove)
+    for t = 1:length(targets_to_remove)
+        target_to_remove = targets_to_remove{t};
+        for i = 1:length(raw_label_list)
+            if any(contains(cellstr(raw_label_list{i}), target_to_remove))
+                idx_to_remove = [idx_to_remove i];
+            end
+        end
+    end
+end
+
+raw_spectrum_list(idx_to_remove) = [];
+raw_label_list(idx_to_remove) = [];
+
 it_list = cellfun(@(data, label) NNDataPoint_RamanSpectra( ...
     'SP_DATA', data, ...
     'WL', dproc.getCallback('WAVELENGTH'), ...
@@ -71,11 +87,16 @@ dp_list = IndexedDictionary(...
         );
 
 value = NNDataset( ...
-    'DP_CLASS', 'NNDataPoint_SpectrumSignal', ...
+    'DP_CLASS', 'NNDataPoint_RamanSpectra', ...
     'DP_DICT', dp_list ...
     );
 
 %% ¡props!
+
+%%% ¡prop!
+TARGETS_TO_REMOVE (data, stringlist) contains the directory of the b2 file for spectrum data.
+%%%% ¡default!
+{'ps'}
 
 %%% ¡prop!
 RAW_DATA_DIR (data, string) contains the directory of the b2 file for spectrum data.

--- a/VariationalAutoencoderRamanSpectra/_NNVariationalAutoencoderEvaluator_RS.gen.m
+++ b/VariationalAutoencoderRamanSpectra/_NNVariationalAutoencoderEvaluator_RS.gen.m
@@ -96,12 +96,15 @@ IDX_LABEL_OF_INTEREST (parameter, scalar) indentifies importance peaks.
 
 %%% ¡prop!
 PEAK_IDENTIFICATION (result, rvector) indentifies importance peaks.
+%%%% ¡calculate!
 
 %%% ¡prop!
 ZERO_CROSSING_P2N (query, rvector) indentifies the index when crossing from positve to negative.
+%%%% ¡calculate!
 
 %%% ¡prop!
 ZERO_CROSSING_N2P (query, rvector) indentifies the index when crossing from negative to positive.
+%%%% ¡calculate!
 
 %%% ¡prop!
 DIRECTORY (data, string) is the directory saving the exporting figure.

--- a/VariationalAutoencoderRamanSpectra/_NNVariationalAutoencoderEvaluator_RS.gen.m
+++ b/VariationalAutoencoderRamanSpectra/_NNVariationalAutoencoderEvaluator_RS.gen.m
@@ -1,5 +1,5 @@
 %% ¡header!
-NNVariationalAutoencoderEvaluator_RamanSpectral < NNVariationalAutoencoderEvaluator (nne, neural network evaluator) evaluates the performance of a trained neural network model with a dataset.
+NNVariationalAutoencoderEvaluator_RS < NNVariationalAutoencoderEvaluator (nne, neural network evaluator) evaluates the performance of a trained neural network model with a dataset.
 
 %%% ¡description!
 A neural network evaluator (NNEvaluator) evaluates the performance of a neural network model with a specific dataset.
@@ -17,7 +17,7 @@ NNDataPoint, NNDataset, NNBase
 %%% ¡prop!
 ELCLASS (constant, string) is the class of the evaluator of the neural network analysis.
 %%%% ¡default!
-'NNVariationalAutoencoder_RamanSpectralEvaluator'
+'NNVariationalAutoencoderEvaluator_RS'
 
 %%% ¡prop!
 NAME (constant, string) is the name of the evaluator for the neural network analysis.
@@ -32,7 +32,7 @@ DESCRIPTION (constant, string) is the description of the evaluator for the neura
 %%% ¡prop!
 TEMPLATE (parameter, item) is the template of the evaluator for the neural network analysis.
 %%%% ¡settings!
-'NNVariationalAutoencoder_RamanSpectralEvaluator'
+'NNVariationalAutoencoderEvaluator_RS'
 
 %%% ¡prop!
 ID (data, string) is a few-letter code for the evaluator for the neural network analysis.
@@ -49,7 +49,51 @@ NOTES (metadata, string) are some specific notes about the evaluator for the neu
 %%%% ¡default!
 'NNEvaluator notes'
 
+%%% ¡prop!
+PREDICT_ENCODER (query, cell) returns the predictions of an encoder.
+%%%% ¡calculate!
+if isempty(varargin)
+    value = {};
+    return
+end
+
+netE = varargin{1};
+mbq = varargin{2};
+d = nne.get('D');
+num_dp = d.get('DP_DICT').get('LENGTH');
+label_of_interest = nne.get('IDX_LABEL_OF_INTEREST')
+for i = 1:num_dp
+    target_classes = char(d.get('DP_DICT').get('IT', i).get('TARGET_CLASS'));
+    targets(i) = categorical(cellstr(strtrim(target_classes(label_of_interest, :))));
+end
+Z = [];
+Y = [];
+
+% Loop over mini-batches.
+while hasdata(mbq)
+    [X_individual, Y_individual] = next(mbq);
+
+    % Forward through encoder.
+    %Z_individual = predict(netE,X_individual,Outputs='latentOuput');
+    [Z_individual, mu, logSigmaSq] = predict(netE, X_individual);
+    
+    % Extract and concatenate predictions.
+    %Z = cat(2,Z,extractdata(Z_individual));
+    Z = cat(2, Z, extractdata(mu));
+
+    Y_individual = extractdata(gather(Y_individual));
+    Y_number = targets(Y_individual);
+    Y = cat(2, Y, Y_number);
+end
+
+value = [{Z}, {Y}];
+
 %% ¡props!
+%%% ¡prop!
+IDX_LABEL_OF_INTEREST (parameter, scalar) indentifies importance peaks.
+%%%% ¡default!
+2
+
 %%% ¡prop!
 PEAK_IDENTIFICATION (result, rvector) indentifies importance peaks.
 
@@ -71,4 +115,4 @@ PLOT_R_SCRIPT (metadata, logical) indentifies the index when crossing from negat
 %% ¡tests!
 
 %%% ¡excluded_props!
-[NNVariationalAutoencoder_RamanSpectralEvaluator.PLOT_LATENT_REPRESENTATIONS NNVariationalAutoencoder_RamanSpectralEvaluator.PLOT_LATENT_CONTINUITY NNVariationalAutoencoder_RamanSpectralEvaluator.PREDICT_ENCODER]
+[NNVariationalAutoencoderEvaluator_RS.PLOT_LATENT_REPRESENTATIONS NNVariationalAutoencoderEvaluator_RS.PREDICT_ENCODER]

--- a/VariationalAutoencoderRamanSpectra/example_VAEMLP_RamanSpectra.m
+++ b/VariationalAutoencoderRamanSpectra/example_VAEMLP_RamanSpectra.m
@@ -9,15 +9,16 @@ dproc = NNDatasetProcess_RamanSpectra( ...
     'RAW_DATA_DIR', [fileparts(which('NNDatasetProcess_RamanSpectra')) filesep 'b2_files'], ...
     'TRANSFORMATION_RULE', 'First derivative', ...
     'NORMALIZATION_RULE', 'Scale', ...
-    'SCALE_FACTOR', 100);
+    'SCALE_FACTOR', 100, ...
+    'TARGETS_TO_REMOVE', {'ps'});
 d_sp = dproc.get('D');
 
 %% Train a Variational Autoencoder
-nnvae = NNVariationalAutoencoderMLP('D', d_sp, 'EPOCHS', 10, 'BATCH', 32);
+nnvae = NNVariationalAutoencoderMLP('D', d_sp, 'EPOCHS', 100, 'BATCH', 32);
 nnvae.get('TRAIN')
 
 %% Evaluate and Visualize Latent Space
-nne = NNVariationalAutoencoderEvaluator('NN', nnvae, 'D', d_sp);
+nne = NNVariationalAutoencoderEvaluator_RS('NN', nnvae, 'D', d_sp);
 
 % latent space
 figure

--- a/testtt.m
+++ b/testtt.m
@@ -1,2 +1,83 @@
-dproc = NNDatasetProcess_MNIST();
+%% BUG NAMING
+% It cannot name NNDataPoint_Spectrum as the getPropDefault will give you case
+%  NNDataPoint_1 for ELCLASS etc.
+%  "NNDataPoint_Spectrum" gives you "case NNDataPoint_1" 
+%  "NNDataPoint_RamanSpectrum" gives you "case NNDataPoint_Raman1" 
+%  This problem arises when it executed hard-coded constants.
+%  My guess is that there is one element called "Spectrum", and this
+%  interven any other elements "ending" with "Spectrum". This also explains
+%  why "NNDataPoint_Graph_CLA" is ok.
+%  Change to NNDataPoint_SpectrumSignal solved the
+%  problem.
+
+%% reset
+close all; delete(findall(0, 'type', 'figure')); clear all
+
+%% copy folders
+%el_to_edit = ['VariationalAutoencoders_RamanSpectrum']
+%el_to_edit = ['VariationalAutoencoders_MNIST']
+el_to_edit = ['VariationalAutoencoderMLP']
+el_to_compile = ['braph2genesis' filesep 'pipelines' filesep el_to_edit]
+copyfile(el_to_edit, el_to_compile);
+
+%% first compilation
+el_path = [filesep 'pipelines' filesep el_to_edit];
+%el_class_list = {'NNDatasetProcess_MNIST' 'NNVariationalAutoencoder'};
+%el_class_list = {'NNDataPoint_Image'};
+%el_class_list = {'NNDataPoint_Spectrum' 'NNDatasetProcess_Spectrum'}; 
+
+el_class_list = {'NNVariationalAutoencoderMLP'};
+regenerate(el_path, el_class_list, 'DoubleCompilation', false)
+
+%% dependent class compiletion
+el_path = [filesep 'src' filesep 'nn'];
+el_class_list = {'NNDataPoint' 'NNBase' 'NNDataset'}
+regenerate(el_path, el_class_list, 'DoubleCompilation', true)
+
+%% second compiletion
+el_path = [filesep 'pipelines' filesep el_to_edit];
+%el_class_list = {'NNDatasetProcess_MNIST' 'NNVariationalAutoencoder'};
+%el_class_list = {'NNDataPoint_Image'};
+%el_class_list = {'NNDataPoint_Spectrum' 'NNDatasetProcess_Spectrum'};
+%el_class_list = {'NNVariationalAutoencoder' 'NNVariationalAutoencoder2DCNN' 'NNVariationalAutoencoderEvaluator'};
+el_class_list = {'NNVariationalAutoencoderMLP'};
+regenerate(el_path, el_class_list, 'DoubleCompilation', true)
+
+%%
+dproc = NNDatasetProcess_SpectrumSignal( ...
+    'RAW_DATA_DIR', [fileparts(which('NNDatasetProcess_SpectrumSignal')) filesep 'b2_files']);
+d_sp = dproc.get('D');
+
+%%
+nnvae = NNVariationalAutoencoders_Structured('D', d_sp, 'EPOCHS', 2, 'BATCH', 8);
+%nnvae.get('TARGETS', d_sp)
+nnvae.get('TRAIN')
+
+%%
+nne = NNVariationalAutoencoders_Evaluator('NN', nnvae, 'D', d_mnist);
+nne.get('PLOT_LATENT_REPRESENTATIONS')
+nne.get('PLOT_LATENT_CONTINUITY')
+
+
+%%
+dproc = NNDatasetProcess_MNIST( ...
+    'MNIST_IMAGE_FILE', [fileparts(which('NNDatasetProcess_MNIST')) filesep 'mnist_data' filesep 'train-images-idx3-ubyte.gz'], ...
+    'MNIST_LABEL_FILE', [fileparts(which('NNDatasetProcess_MNIST')) filesep 'mnist_data' filesep 'train-labels-idx1-ubyte.gz'] ...
+    );
 d_mnist = dproc.get('D');
+
+%%
+inputs = NNVariationalAutoencoders().get('INPUTS', d_mnist);
+
+trainImagesFile = "train-images-idx3-ubyte.gz";
+XTrain = processImagesMNIST(trainImagesFile);
+
+
+%%
+nnvae = NNVariationalAutoencoders('D', d_mnist, 'EPOCHS', 2, 'BATCH', 128);
+nnvae.get('TRAIN')
+
+%%
+nne = NNVariationalAutoencoders_Evaluator('NN', nnvae, 'D', d_mnist);
+nne.get('PLOT_LATENT_REPRESENTATIONS')
+nne.get('PLOT_LATENT_CONTINUITY')


### PR DESCRIPTION
### This PR implements MATLAB calling R scripts via Docker.
This solution avoids the common “**works on my machine**” problem: different users, OS versions, or R package versions can easily break reproducibility.
Specifically, it replicates two R scripts, _fig_palette_p1.R_ and _plot_ls_qnorm_med.R_, which export the highlighted figures shown in the attached screenshot.
<img width="1470" height="956" alt="Screenshot 2025-09-11 at 17 26 20" src="https://github.com/user-attachments/assets/182b6ec1-53c3-41b2-9b74-99faa7b85409" />

To achieve this, a Docker environment is used to provide R and all required dependencies, ensuring reproducibility and stability while sparing users from versioning or runtime installation issues. Compared to simply installing R and packages locally, Docker guarantees a controlled and portable environment, so results can be reproduced consistently across different machines and operating systems.

This PR:

- **Adds a Dockerfile to build a stable environment.**
- **Modifies the two R scripts to remove runtime installation.**

Steps to replicate:

1. Check Docker installation
Run docker version. If not installed, show a warning message: “Please see [[link](https://gethomepage.dev/installation/docker/)] to install Docker.”
2. Build the Docker image
`docker build --no-cache -t r-ls-plot:latest .`
3. Run the scripts
```
docker run --rm -v "$PWD":/work -w /work r-ls-plot:latest Rscript fig_palette_p1.R
docker run --rm -v "$PWD":/work -w /work r-ls-plot:latest Rscript plot_ls_qnorm_med.R
```